### PR TITLE
Work on getting Swift 5+ support [don't merge yet]

### DIFF
--- a/prepare-toolchain
+++ b/prepare-toolchain
@@ -56,40 +56,17 @@ cd swift-source
 git clone https://github.com/apple/swift.git
 swift/utils/update-checkout --clone --tag "swift-${version}-RELEASE"
 
+ln -s ./llvm-project/llvm ./llvm
+ln -s ./llvm-project/clang ./clang
+
 # patch clang
+info "Patching Clang"
 sed -i '' -e 's;__has_include(<CoreServices/CoreServices.h>);__has_include(<FSEvents/FSEvents.h>);g' clang/lib/DirectoryWatcher/DirectoryWatcher.cpp
 
 # compile swift
+# see here for preset info: https://github.com/apple/swift/blob/master/utils/build-presets.ini#L2105
 info "Compiling Swift"
-swift/utils/build-script \
---build-subdir=LLVMClangSwift_iphoneos \
---release \
--- \
---install-swift \
---install-destdir=output \
---swift-install-components="compiler;clang-builtin-headers;editor-integration;tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;" \
---install-prefix=/usr \
---cross-compile-hosts=iphoneos-arm64 \
---compiler-vendor=apple \
---swift-primary-variant-sdk=IOS \
---swift-primary-variant-arch=arm64 \
---build-toolchain-only=1 \
---build-swift-static-stdlib=0 \
---build-swift-dynamic-stdlib=0 \
---build-swift-static-sdk-overlay=0 \
---build-swift-dynamic-sdk-overlay=0 \
---build-runtime-with-host-compiler=0 \
---skip-local-host-install \
---skip-build-benchmarks \
---skip-test-sourcekit \
---skip-test-swift \
---llvm-include-tests=0 \
---llvm-enable-modules=0 \
---build-swift-examples=0 \
---swift-include-tests=0 \
---darwin-deployment-version-ios=10.0 \
---darwin-crash-reporter-client=1 \
---reconfigure
+./swift/utils/build-script --preset "buildbot_iphoneos_arm64_crosscompiler"
 cd ..
 
 info "Merging toolchains"


### PR DESCRIPTION
Still haven't gotten this to build successfully, but I wanted to put this here for potential feedback or at least to show what I've figured out so far. You're welcome to close if you don't want a half-completed PR sitting here.

**Setup** 
macOS 10.15.2 (Catalina)
Xcode 11.3.1 or Xcode 11.4 beta (same result with both)
swift-5.1.4-RELEASE

The swift build script seems to expect `clang` and `llvm` to be top level in the `swift-source` directory, hence the symlinks. This *looks* like an obvious bug, so it may not be needed in the future.

The clang patch seems like it's still needed. The build fails early without it.

With this setup it's able to build cmark and llvm for both macos and iphoneos, and swift for macosx, but then it fails on swift for iphoneos with this:
```
-- Build files have been written to: /Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/swift-iphoneos-arm64
+ popd
~/projects/swift-toolchain-ios/toolchains/swift-source
+ /usr/local/bin/cmake --build /Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/swift-iphoneos-arm64 -- -j4 all
[1/779][  0%][0.005s] Building CXX object stdlib/toolchain/Compatibility50/CMakeFiles/swiftCompatibility50-iphoneos-armv7s.dir/ProtocolConformance.cpp.o
FAILED: stdlib/toolchain/Compatibility50/CMakeFiles/swiftCompatibility50-iphoneos-armv7s.dir/ProtocolConformance.cpp.o 
/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/llvm-iphoneos-arm64/./bin/clang++  -DCMARK_STATIC_DEFINE -DGTEST_HAS_RTTI=0 -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Istdlib/toolchain/Compatibility50 -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/swift/stdlib/toolchain/Compatibility50 -Iinclude -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/swift/include -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/llvm/include -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/llvm-iphoneos-arm64/include -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/llvm/tools/clang/include -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/llvm-iphoneos-arm64/tools/clang/include -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/cmark/src -I/Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/cmark-iphoneos-arm64/src -Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -std=c++11 -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-class-memaccess -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fdiagnostics-color -Werror=switch -Wdocumentation -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fno-sanitize=all -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1 -O3  -isysroot /Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.4.sdk   -UNDEBUG  -fno-exceptions -fno-rtti -DSWIFT_TARGET_LIBRARY_NAME=swiftCompatibility50 -target armv7s-apple-ios10.0 -isysroot /Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.4.sdk -arch armv7s -F /Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.4.sdk/../../../Developer/Library/Frameworks -mios-version-min=10.0 -O2 -g0 -UNDEBUG -DSWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS -MD -MT stdlib/toolchain/Compatibility50/CMakeFiles/swiftCompatibility50-iphoneos-armv7s.dir/ProtocolConformance.cpp.o -MF stdlib/toolchain/Compatibility50/CMakeFiles/swiftCompatibility50-iphoneos-armv7s.dir/ProtocolConformance.cpp.o.d -o stdlib/toolchain/Compatibility50/CMakeFiles/swiftCompatibility50-iphoneos-armv7s.dir/ProtocolConformance.cpp.o -c /Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/swift/stdlib/toolchain/Compatibility50/ProtocolConformance.cpp
/bin/sh: /Users/mike/projects/swift-toolchain-ios/toolchains/swift-source/build/LLVMClangSwift_iphoneos/llvm-iphoneos-arm64/./bin/clang++: Bad CPU type in executable
[4/779][  0%][0.013s] Generating ../../../lib/swift/iphoneos/layouts-armv7.yaml
ninja: build stopped: subcommand failed.
```

Trying to build toolchain versions prior to 5.1.4 result in different errors. 5.1.3 in particular has [this issue](https://forums.swift.org/t/cant-build-swift-5-1-toolchain/32403), which is why I've been using 5.1.4 (it seems to make it the furthest in the build process).