### PR TITLE
Fix script, add Swift v5 support*, and add workflow  

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,12 @@ name: Build
 
 on:
   push:
-    tags:
-    - '*'
+  workflow_dispatch:
 
 jobs:
   host-build:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@main
       - name: Host Toolchain Prep
         run: |
           brew install ninja
@@ -61,24 +59,24 @@ jobs:
       - name: Upload Host Toolchain Artifact
         uses: actions/upload-artifact@main
         with:
-          name: LLVMClangSwift_iphoneos-Container
+          name: LLVMClangSwift_iphoneos
           path: ~/LLVMClangSwift_iphoneos.zip
 
   ios-build:
     needs: host-build
     runs-on: macos-11
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@main
-      - name: Download artifact
+      - name: Download Artifact
         uses: actions/download-artifact@main
-      - name: Extract host tc from artifact
+        with:
+          name: LLVMClangSwift_iphoneos
+
+      - name: Extract Host Toolchain
         run: |
-          set -x
-          for container in ./*Container; do
-            if [[ -d "$container" ]]; then
-              unzip $container/*.zip -d $HOME
-            fi
-          done
+          unzip LLVMClangSwift_iphoneos.zip -d $HOME
 
       - name: The Work
         run: |
@@ -86,47 +84,19 @@ jobs:
           pip install --user six
           ./prepare-toolchain 5.5.1 /Applications/Xcode_13.1.app
 
-      - name: Build Deb
-        uses: L1ghtmann/theos-build@main
-        with:
-          extra_args: "FINALPACKAGE=1"
-
-      - uses: actions/upload-artifact@main
-        with:
-          name: package
-          path: packages/*.deb
-
-  upload:
-    needs: ios-build
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@main
-      - name: Download Artifacts
-        uses: actions/download-artifact@main
-        with:
-          name: package
-          with: ~/package
-
-      - name: Set TAG Variable
+      - name: Set up Theos
         run: |
-          echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+          brew install ldid make xz
+          git clone --recursive https://github.com/theos/theos.git ~/theos
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        with:
-          tag_name: ${{ env.TAG }}
-          release_name: ${{ env.TAG }}
-          body: ''
-          draft: false
+      - name: Build Deb
+        run: |
+          export THEOS=~/theos
+          gmake clean package FINALPACKAGE=1
 
       - name: Attach Deb To Release
         run: |
           set -x
-          debs=()
-          for deb in ~/**/*.deb; do
-            debs+=("-a" "$deb")
-          done
-          hub release edit "${debs[@]}" -m "$TAG" "$TAG"
+          TAG="${GITHUB_REF##*/}-${GITHUB_SHA:0:7}"
+          gh release create "$TAG" --draft --title "Draft Release"
+          gh release upload "$TAG" packages/*.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         with:
-          tag_name: $TAG
-          release_name: $TAG
+          tag_name: ${{ env.TAG }}
+          release_name: ${{ env.TAG }}
           body: ''
           draft: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,15 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    tags:
+    - '*'
 
 jobs:
   host-build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@main
-      - name: Host tc prep work
+      - name: Host Toolchain Prep
         run: |
           brew install ninja
           pip install --user six
@@ -18,7 +19,7 @@ jobs:
           git clone --depth=1 https://github.com/apple/swift.git
           swift/utils/update-checkout --clone --tag "swift-5.5.1-RELEASE" -j "$(sysctl -n hw.ncpu)"
 
-      - name: Build Swift Compiler for host
+      - name: Build Swift Compiler For Host
         run: |
           export DEVELOPER_DIR="/Applications/Xcode_13.1.app/Contents/Developer/"
           export SKIP_XCODE_VERSION_CHECK=1
@@ -52,12 +53,12 @@ jobs:
             --reconfigure
           mv -v build/LLVMClangSwift_iphoneos/ $HOME
 
-      - name: Prep host tc for artifact upload
+      - name: Prep Host Toolchain For Artifact Upload
         run: |
           cd $HOME
           zip -9 -r LLVMClangSwift_iphoneos.zip LLVMClangSwift_iphoneos
 
-      - name: Upload host tc artifact
+      - name: Upload Host Toolchain Artifact
         uses: actions/upload-artifact@main
         with:
           name: LLVMClangSwift_iphoneos-Container
@@ -65,7 +66,7 @@ jobs:
 
   ios-build:
     needs: host-build
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@main
       - name: Download artifact
@@ -79,13 +80,13 @@ jobs:
             fi
           done
 
-      - name: The work
+      - name: The Work
         run: |
           export SKIP_XCODE_VERSION_CHECK=1
           pip install --user six
           ./prepare-toolchain 5.5.1 /Applications/Xcode_13.1.app
 
-      - name: theos-build
+      - name: Build Deb
         uses: L1ghtmann/theos-build@main
         with:
           extra_args: "FINALPACKAGE=1"
@@ -98,32 +99,34 @@ jobs:
   upload:
     needs: ios-build
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@main
-      - name: Download artifacts
+      - name: Download Artifacts
         uses: actions/download-artifact@main
         with:
           name: package
           with: ~/package
 
-      - name: Create release
+      - name: Set TAG Variable
+        run: |
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+
+      - name: Create Release
         id: create_release
         uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: 5.5.1
-          release_name: Swift Toolchain (v5.5.1)
+          tag_name: $TAG
+          release_name: $TAG
+          body: ''
           draft: false
-          prerelease: false
 
-      - name: Attach debs to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach Deb To Release
         run: |
           set -x
           debs=()
           for deb in ~/**/*.deb; do
             debs+=("-a" "$deb")
           done
-          hub release edit "${debs[@]}" -m "Swift Toolchain (v5.5.1)" "5.5.1"
+          hub release edit "${debs[@]}" -m "$TAG" "$TAG"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,126 @@
+name: Build
+
+on:
+  push:
+    branches: [ pr ]
+
+jobs:
+  host-build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Host tc prep work
+        run: |
+          brew install ninja
+          pip install --user six
+          echo "[info] Checking out Swift repo"
+          mkdir swift-source && cd swift-source
+          git clone --depth=1 https://github.com/apple/swift.git
+          swift/utils/update-checkout --clone --tag "swift-5.5.1-RELEASE" -j "$(sysctl -n hw.ncpu)"
+
+      - name: Build Swift Compiler for host
+        run: |
+          export DEVELOPER_DIR="/Applications/Xcode_13.1.app/Contents/Developer/"
+          export SKIP_XCODE_VERSION_CHECK=1
+          echo "[info] Compiling host tc"
+          cd swift-source
+          swift/utils/build-script \
+            --build-subdir=LLVMClangSwift_iphoneos \
+            --release \
+            -- \
+            --install-swift \
+            --install-prefix=/usr \
+            --llvm-install-components="clang;compiler-rt" \
+            --swift-install-components="compiler" \
+            --cmake-generator=Ninja \
+            --extra-cmake-options="-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64" \
+            --build-args="-j$(sysctl -n hw.ncpu)" \
+            --skip-build-benchmarks \
+            --skip-build-clang-tools-extra \
+            --skip-build-android \
+            --skip-test-sourcekit \
+            --skip-test-swift \
+            --skip-build-tvos \
+            --skip-test-tvos \
+            --skip-build-watchos \
+            --skip-test-watchos \
+            --llvm-include-tests=0 \
+            --llvm-enable-modules=0 \
+            --build-swift-examples=0 \
+            --swift-include-tests=0 \
+            --darwin-crash-reporter-client=1 \
+            --reconfigure
+          mv -v build/LLVMClangSwift_iphoneos/ $HOME
+
+      - name: Prep host tc for artifact upload
+        run: |
+          cd $HOME
+          zip -9 -r LLVMClangSwift_iphoneos.zip LLVMClangSwift_iphoneos
+
+      - name: Upload host tc artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: LLVMClangSwift_iphoneos-Container
+          path: ~/LLVMClangSwift_iphoneos.zip
+
+  ios-build:
+    needs: host-build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Download artifact
+        uses: actions/download-artifact@main
+      - name: Extract host tc from artifact
+        run: |
+          set -x
+          for container in ./*Container; do
+            if [[ -d "$container" ]]; then
+              unzip $container/*.zip -d $HOME
+            fi
+          done
+
+      - name: The work
+        run: |
+          export SKIP_XCODE_VERSION_CHECK=1
+          pip install --user six
+          ./prepare-toolchain 5.5.1 /Applications/Xcode_13.1.app
+
+      - name: theos-build
+        uses: L1ghtmann/theos-build@main
+        with:
+          extra_args: "FINALPACKAGE=1"
+
+      - uses: actions/upload-artifact@main
+        with:
+          name: package
+          path: packages/*.deb
+
+  upload:
+    needs: ios-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Download artifacts
+        uses: actions/download-artifact@main
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: 5.5.1
+          release_name: Swift Toolchain (v5.5.1)
+          draft: false
+          prerelease: false
+
+      - name: Attach debs to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          debs=()
+          for deb in **/*.deb; do
+            debs+=("-a" "$deb")
+          done
+          hub release edit "${debs[@]}" -m "Swift Toolchain (v5.5.1)" "5.5.1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,7 @@ jobs:
         uses: actions/download-artifact@main
         with:
           name: package
+          with: ~/package
 
       - name: Create release
         id: create_release
@@ -122,7 +123,7 @@ jobs:
         run: |
           set -x
           debs=()
-          for deb in **/*.deb; do
+          for deb in ~/**/*.deb; do
             debs+=("-a" "$deb")
           done
           hub release edit "${debs[@]}" -m "Swift Toolchain (v5.5.1)" "5.5.1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ pr ]
+    branches: [ master ]
 
 jobs:
   host-build:
@@ -102,6 +102,8 @@ jobs:
       - uses: actions/checkout@main
       - name: Download artifacts
         uses: actions/download-artifact@main
+        with:
+          name: package
 
       - name: Create release
         id: create_release

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Kabir Oberai
+Copyright (c) 2018-2022 Kabir Oberai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2022 Kabir Oberai
+Copyright (c) 2018-2023 Kabir Oberai
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ override PACKAGE_VERSION := $(SWIFT_VERSION)-$(BUILD)
 include $(THEOS)/makefiles/common.mk
 include $(THEOS_MAKE_PATH)/null.mk
 
-_THEOS_CONTROL_FILE = $(_THEOS_ESCAPED_STAGING_DIR)/DEBIAN/control
-SWIFT_VERSION_DEPENDS = com.modmyi.libswift4 (>= $(SWIFT_VERSION))
+_THEOS_CONTROL_FILE = $(THEOS_STAGING_DIR)/DEBIAN/control
+SWIFT_VERSION_DEPENDS = org.swift.libswift (>= $(SWIFT_VERSION))
 
 ifeq ($(SWIFT_VERSION),)
 before-all::

--- a/control
+++ b/control
@@ -5,4 +5,4 @@ Architecture: iphoneos-arm
 Description: Swift toolchain cross-compiled for iOS
 Author: Kabir Oberai <support@kabiroberai.com>
 Maintainer: Kabir Oberai <support@kabiroberai.com>
-Depends: firmware (>= 7.0), cy+cpu.arm64, ${SWIFT_VERSION}
+Depends: firmware (>= 10.0), cy+cpu.arm64, ${SWIFT_VERSION}

--- a/prepare-toolchain
+++ b/prepare-toolchain
@@ -21,7 +21,7 @@ mkdir -p toolchains
 cd toolchains
 info "Downloading macOS toolchain"
 if ! [[ -f "toolchain-${version}.pkg" ]]; then
-	curl -#o "toolchain-${version}.pkg" "https://swift.org/builds/swift-${version}-release/xcode/swift-${version}-RELEASE/${file_name}.pkg"
+	curl -Lo "toolchain-${version}.pkg" "https://swift.org/builds/swift-${version}-release/xcode/swift-${version}-RELEASE/${file_name}.pkg"
 fi
 
 info "Unpacking toolchain"

--- a/prepare-toolchain
+++ b/prepare-toolchain
@@ -129,9 +129,11 @@ cd usr/
 find . \( -type f \( -name '*.dylib' -or \( -path './bin/*' -not -name '*.py' \) \) -or \( -path '*.framework/*' -not -name '*.*' \) -not -name '.DS_Store' \) -print0 | xargs -0 -I{} sh -c "ldid -S../../ent.xml {} || :"
 
 copy_file() {
-	mkdir -p share/swift_stash/"$(dirname "$1")"
-	mv -v "$1" share/swift_stash/"$(dirname "$1")"
-	ln -fs /usr/share/swift_stash/"$1" "$1"
+	# Remove "./" from the file path
+	file="$(echo $1 | cut -c 3-)"
+	mkdir -p share/swift_stash/"$(dirname "$file")"
+	mv -v "$file" share/swift_stash/"$(dirname "$file")"
+	ln -fs /usr/share/swift_stash/"$file" "$file"
 }
 
 export -f copy_file

--- a/prepare-toolchain
+++ b/prepare-toolchain
@@ -21,14 +21,14 @@ mkdir -p toolchains
 cd toolchains
 info "Downloading macOS toolchain"
 if ! [[ -f "toolchain-${version}.pkg" ]]; then
-	curl -Lo "toolchain-${version}.pkg" "https://swift.org/builds/swift-${version}-release/xcode/swift-${version}-RELEASE/${file_name}.pkg"
+	curl -#o "toolchain-${version}.pkg" "https://swift.org/builds/swift-${version}-release/xcode/swift-${version}-RELEASE/${file_name}.pkg"
 fi
 
 info "Unpacking toolchain"
 # remove any pre-existing usr dir first
 rm -rf usr
 xar -xvf "toolchain-${version}.pkg" "${package}/Payload"
-tar -xzvf "${package}/Payload" "usr"
+tar -xvf "${package}/Payload" "usr"
 rm -rf "${package}"
 
 info "Modifying macOS toolchain"
@@ -141,6 +141,6 @@ export -f copy_file
 find . -type f -print0 | xargs -0 -I{} sh -c 'copy_file {}'
 
 cd ..
-mv -v usr "usr-${version}"
+mv usr "usr-${version}"
 
 echo "${version}" > .version

--- a/prepare-toolchain
+++ b/prepare-toolchain
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 shopt -s extglob
 cd "$(dirname "$0")"
 
-if [[ $# -ne 2 ]]; then 
+if [[ $# -ne 2 ]]; then
 	echo "Usage: $0 <version> <path to correct Xcode.app>"
 	exit 1
 fi
@@ -19,15 +20,15 @@ package="${file_name}-package.pkg"
 mkdir -p toolchains
 cd toolchains
 info "Downloading macOS toolchain"
-if [[ ! -f "toolchain-${version}.pkg" ]]; then
-	curl -#o "toolchain-${version}.pkg" "https://swift.org/builds/swift-${version}-release/xcode/swift-${version}-RELEASE/${file_name}.pkg"
+if ! [[ -f "toolchain-${version}.pkg" ]]; then
+	curl -Lo "toolchain-${version}.pkg" "https://swift.org/builds/swift-${version}-release/xcode/swift-${version}-RELEASE/${file_name}.pkg"
 fi
 
 info "Unpacking toolchain"
 # remove any pre-existing usr dir first
 rm -rf usr
-xar -xf "toolchain-${version}.pkg" "${package}/Payload"
-tar -xzf "${package}/Payload" "usr"
+xar -xvf "toolchain-${version}.pkg" "${package}/Payload"
+tar -xzvf "${package}/Payload" "usr"
 rm -rf "${package}"
 
 info "Modifying macOS toolchain"
@@ -38,70 +39,98 @@ for file in libswift*.dylib; do
 	# symlink to the libswift package
 	ln -fs "/usr/lib/libswift/${version}/${file}" "${file}"
 done
-cd ../../../..
+cd ../../../../
 
 info "Installing dependencies"
-type brew &>/dev/null || ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+type brew &>/dev/null || bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 type cmake &>/dev/null || brew install cmake
+type ldid &>/dev/null || brew install ldid
 type ninja &>/dev/null || brew install ninja
 
 info "Checking out Swift repo"
-
 if [[ -d swift-source ]]; then
 	rm -rf swift-source
 fi
 
 mkdir swift-source
 cd swift-source
-git clone https://github.com/apple/swift.git
-swift/utils/update-checkout --clone --tag "swift-${version}-RELEASE"
+git clone --depth=1 https://github.com/apple/swift.git
+swift/utils/update-checkout --clone --tag "swift-${version}-RELEASE" -j "$(sysctl -n hw.ncpu)"
 
 # patch clang
-sed -i '' -e 's;__has_include(<CoreServices/CoreServices.h>);__has_include(<FSEvents/FSEvents.h>);g' clang/lib/DirectoryWatcher/DirectoryWatcher.cpp
+sed -i '' -e 's;__has_include(<CoreServices/CoreServices.h>);__has_include(<FSEvents/FSEvents.h>);g' llvm-project/clang/lib/DirectoryWatcher/mac/DirectoryWatcher-mac.cpp
+
+# for use with workflow
+if [[ ! -z $CI && -d $HOME/LLVMClangSwift_iphoneos ]]; then
+	info "Installing pre-compiled host toolchain"
+	mkdir -p build/ && mv -v $HOME/LLVMClangSwift_iphoneos build/
+fi
 
 # compile swift
 info "Compiling Swift"
-swift/utils/build-script \
---build-subdir=LLVMClangSwift_iphoneos \
---release \
--- \
---install-swift \
---install-destdir=output \
---swift-install-components="compiler;clang-builtin-headers;editor-integration;tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;" \
---install-prefix=/usr \
---cross-compile-hosts=iphoneos-arm64 \
---compiler-vendor=apple \
---swift-primary-variant-sdk=IOS \
---swift-primary-variant-arch=arm64 \
---build-toolchain-only=1 \
---build-swift-static-stdlib=0 \
---build-swift-dynamic-stdlib=0 \
---build-swift-static-sdk-overlay=0 \
---build-swift-dynamic-sdk-overlay=0 \
---build-runtime-with-host-compiler=0 \
---skip-local-host-install \
---skip-build-benchmarks \
---skip-test-sourcekit \
---skip-test-swift \
---llvm-include-tests=0 \
---llvm-enable-modules=0 \
---build-swift-examples=0 \
---swift-include-tests=0 \
---darwin-deployment-version-ios=10.0 \
---darwin-crash-reporter-client=1 \
---reconfigure
+ARGS=(
+	--build-subdir=LLVMClangSwift_iphoneos \
+	--release \
+	-- \
+	--install-swift \
+	--install-destdir=output \
+	--swift-install-components="compiler;clang-builtin-headers;editor-integration;tools;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;" \
+	--install-prefix=/usr \
+	--cmake-generator=Ninja \
+	--extra-cmake-options="-DLLVM_TARGETS_TO_BUILD=X86;ARM;AArch64" \
+	--cross-compile-hosts=iphoneos-arm64 \
+	--compiler-vendor=apple \
+	--swift-primary-variant-sdk=IOS \
+	--swift-primary-variant-arch=arm64 \
+	--build-args="-j$(sysctl -n hw.ncpu)" \
+	--build-toolchain-only=1 \
+	--build-swift-static-stdlib=0 \
+	--build-swift-dynamic-stdlib=0 \
+	--build-swift-static-sdk-overlay=0 \
+	--build-swift-dynamic-sdk-overlay=0 \
+	--build-runtime-with-host-compiler=0 \
+	--skip-local-host-install \
+	--skip-build-benchmarks \
+	--skip-build-clang-tools-extra \
+	--skip-build-android \
+	--skip-test-sourcekit \
+	--skip-test-swift \
+	--llvm-include-tests=0 \
+	--llvm-enable-modules=0 \
+	--skip-build-osx \
+	--skip-test-osx \
+	--skip-build-tvos \
+	--skip-test-tvos \
+	--skip-build-watchos \
+	--skip-test-watchos \
+	--build-swift-examples=0 \
+	--swift-include-tests=0 \
+	--darwin-deployment-version-ios=10.0 \
+	--darwin-crash-reporter-client=1 \
+)
+if ! [[ -z $CI ]]; then
+	ARGS+=(
+		--skip-local-build \
+	)
+fi
+swift/utils/build-script "${ARGS[@]}" --reconfigure
 cd ..
 
 info "Merging toolchains"
-cp -a "swift-source/output/merged-hosts/usr/bin" usr/
-cp "swift-source/output/merged-hosts/usr/lib/libswiftDemangle.dylib" usr/lib/
+if [[ -z $CI ]]; then
+	cp -av "swift-source/output/merged-hosts/usr/bin" usr/
+	cp -v "swift-source/output/merged-hosts/usr/lib/libswiftDemangle.dylib" usr/lib/
+else
+	cp -av "swift-source/output/usr/bin" usr/
+	cp -v "swift-source/output/usr/lib/libswiftDemangle.dylib" usr/lib/
+fi
 cd usr/
 # Codesign any Mach-O files, also adding the correct entitlements
 find . \( -type f \( -name '*.dylib' -or \( -path './bin/*' -not -name '*.py' \) \) -or \( -path '*.framework/*' -not -name '*.*' \) -not -name '.DS_Store' \) -print0 | xargs -0 -I{} sh -c "ldid -S../../ent.xml {} || :"
 
-function copy_file() {
+copy_file() {
 	mkdir -p share/swift_stash/"$(dirname "$1")"
-	mv "$1" share/swift_stash/"$(dirname "$1")"
+	mv -v "$1" share/swift_stash/"$(dirname "$1")"
 	ln -fs /usr/share/swift_stash/"$1" "$1"
 }
 
@@ -110,6 +139,6 @@ export -f copy_file
 find . -type f -print0 | xargs -0 -I{} sh -c 'copy_file {}'
 
 cd ..
-mv usr "usr-${version}"
+mv -v usr "usr-${version}"
 
 echo "${version}" > .version


### PR DESCRIPTION
*This will build successfully, and the resulting toolchain does appear to *mostly* work on-device, but there are a couple of issues that prevent said toolchain from being ready for release as-is:

1) Executing `swift`/`swift-frontend` results in a crash:
```
<unknown>:0: error: fatal error encountered during compilation; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project
<unknown>:0: note: Compiler-internal integrated REPL has been removed; use the LLDB-enhanced REPL instead.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project and the crash backtrace.
Stack dump:
0.      Program arguments: /usr/share/swift_stash/bin/swift-frontend -frontend -repl -Xllvm -aarch64-use-tbi -enable-objc-interop -color-diagnostics -module-name REPL
1.      Apple Swift version 5.5.1 (swift-5.5.1-RELEASE)
2.
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x0000000103f70520 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x0000000103f6f3d8 llvm::sys::RunSignalHandlers() + 128
2  swift-frontend           0x0000000103f70c04 SignalHandler(int) + 360
3  libsystem_platform.dylib 0x00000001dac2ad90 <redacted> + 52
4  libsystem_pthread.dylib  0x00000001dac3a9e8 pthread_kill + 212
5  libsystem_c.dylib        0x000000019b1f38f4 abort + 100
6  swift-frontend           0x00000001000b9364 PrettyStackTraceFrontend::~PrettyStackTraceFrontend() + 0
7  swift-frontend           0x0000000103ee2258 llvm::report_fatal_error(llvm::Twine const&, bool) + 244
8  swift-frontend           0x0000000103ee2164 llvm::report_fatal_error(llvm::Twine const&, bool) + 0
9  swift-frontend           0x00000001000b91b8 PrettyStackTraceFrontend::~PrettyStackTraceFrontend() + 0
10 swift-frontend           0x0000000100025ac0 main + 468
11 libdyld.dylib            0x000000019215d568 <redacted> + 4
Abort trap: 6
```
- This appears to be a known issue (?) [see [here](https://github.com/apple/swift/issues/57927)]
  - And, yes, llvm-symbolizer is in the PATH

2) There seems to be an issue with the queried include path(s), as trying to compile a [regular swift project](https://github.com/SerenaKit/SuccessorCLI) with the latest master branch theos results in:
```
/var/mobile/theos/sdks/iPhoneOS14.5.sdk/usr/include/module.modulemap:118:11: error: header 'stdarg.h' not found
   header "stdarg.h" // note: supplied by the compiler
          ^
<unknown>:0: error: could not build Objective-C module 'Darwin'
/var/mobile/theos/sdks/iPhoneOS14.5.sdk/usr/lib/swift/Foundation.swiftmodule/arm64-apple-ios.swiftinterface:4:8: error: failed to build module 'Combine'; this SDK is not supported by the compiler (the SDK is built with 'Apple Swift version 5.4 (swiftlang-1205.0.24.14 clang-1205.0.19.54)', while this compiler is 'Apple Swift version 5.5.1 (swift-5.5.1-RELEASE)'). Please select a toolchain which matches the SDK.
``` 
despite the header in question existing in two places:
`/usr/lib/llvm-10/lib/clang/10.0.0/include/stdarg.h`
`/usr/share/swift_stash/lib/clang/10.0.0/include/stdarg.h`
and `swiftc` checking the correct paths:
```
$ swiftc -print-target-info
{
  "compilerVersion": "Apple Swift version 5.5.1 (swift-5.5.1-RELEASE)",
  "target": {
    "triple": "arm64-apple-ios10.0",
    "unversionedTriple": "arm64-apple-ios",
    "moduleTriple": "arm64-apple-ios",
    "swiftRuntimeCompatibilityVersion": "5.0",
    "compatibilityLibraries": [
      {
        "libraryName": "swiftCompatibility50",
        "filter": "all"
      },
      {
        "libraryName": "swiftCompatibility51",
        "filter": "all"
      },
      {
        "libraryName": "swiftCompatibilityDynamicReplacements",
        "filter": "executable"
      }
    ],
    "librariesRequireRPath": true
  },
  "paths": {
    "runtimeLibraryPaths": [
      "/usr/share/swift_stash/lib/swift/iphoneos",
      "/usr/lib/swift"
    ],
    "runtimeLibraryImportPaths": [
      "/usr/share/swift_stash/lib/swift/iphoneos"
    ],
    "runtimeResourcePath": "/usr/share/swift_stash/lib/swift"
  }
}
```

I don't see why the compiler wouldn't support older sdks, so I am assuming it's somehow related to 1 or the include path situation...? 

I've confirmed the symlinks at said paths are valid but am at a loss with how to proceed. Feel free to take it from here, advise if you'd like me to take a look again, or ignore this for the time being. 

Tested on iP7 -- iOS 14.3 -- Unc0ver

Supersedes #3 and "resolves" #2.  